### PR TITLE
shell_plus: `get_{ipython,notebook}_arguments` allow modifying `extra_args`

### DIFF
--- a/django_extensions/management/commands/shell_plus.py
+++ b/django_extensions/management/commands/shell_plus.py
@@ -126,7 +126,7 @@ class Command(BaseCommand):
 
     def get_ipython_arguments(self, options):
         if self.extra_args:
-            return self.extra_args
+            return list(self.extra_args)
         ipython_args = 'IPYTHON_ARGUMENTS'
         arguments = getattr(settings, ipython_args, [])
         if not arguments:
@@ -135,7 +135,7 @@ class Command(BaseCommand):
 
     def get_notebook_arguments(self, options):
         if self.extra_args:
-            return self.extra_args
+            return list(self.extra_args)
         notebook_args = 'NOTEBOOK_ARGUMENTS'
         arguments = getattr(settings, notebook_args, [])
         if not arguments:


### PR DESCRIPTION
In `run_notebook` after `get_ipython_arguments` is called and the result is
modified, but since both `get_ipython_arguments` and `get_notebook_arguments`
refer to the same list this produces an invalid command line.